### PR TITLE
feat(home) adding homescreen & consuming api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ migrate_working_dir/
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-#.vscode/
+.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+  errors:
+    todo: warning
+linter:
+  rules:
+    - lines_longer_than_80_chars

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,21 @@
+import 'dart:io';
+
 import 'package:demo_app/pages/splash_page.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:window_size/window_size.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  await SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+  ]);
+
+  if (Platform.isMacOS) {
+    setWindowMinSize(const Size(500, 600));
+  }
+
   runApp(const MainApp());
 }
 

--- a/lib/models/person.dart
+++ b/lib/models/person.dart
@@ -6,12 +6,15 @@ part 'person.g.dart';
 class Person {
   final int? id;
   final String? name;
+  @JsonKey(name: 'last_name')
   final String? lastName;
   final String? birthday;
   final String? gender;
   final String? state;
   final String? zip;
+  @JsonKey(name: 'photo_url')
   final String? photoUrl;
+  @JsonKey(name: 'title_profession')
   final String? titleProfession;
   final String? quote;
 

--- a/lib/models/person.g.dart
+++ b/lib/models/person.g.dart
@@ -9,25 +9,25 @@ part of 'person.dart';
 Person _$PersonFromJson(Map<String, dynamic> json) => Person(
       id: (json['id'] as num?)?.toInt(),
       name: json['name'] as String?,
-      lastName: json['lastName'] as String?,
+      lastName: json['last_name'] as String?,
       birthday: json['birthday'] as String?,
       gender: json['gender'] as String?,
       state: json['state'] as String?,
       zip: json['zip'] as String?,
-      photoUrl: json['photoUrl'] as String?,
-      titleProfession: json['titleProfession'] as String?,
+      photoUrl: json['photo_url'] as String?,
+      titleProfession: json['title_profession'] as String?,
       quote: json['quote'] as String?,
     );
 
 Map<String, dynamic> _$PersonToJson(Person instance) => <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
-      'lastName': instance.lastName,
+      'last_name': instance.lastName,
       'birthday': instance.birthday,
       'gender': instance.gender,
       'state': instance.state,
       'zip': instance.zip,
-      'photoUrl': instance.photoUrl,
-      'titleProfession': instance.titleProfession,
+      'photo_url': instance.photoUrl,
+      'title_profession': instance.titleProfession,
       'quote': instance.quote,
     };

--- a/lib/navigation/utils.dart
+++ b/lib/navigation/utils.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class NoAnimationRoute extends PageRouteBuilder {
+  final WidgetBuilder builder;
+
+  /// Utility to remove page transition animation
+  NoAnimationRoute({required this.builder, super.settings})
+      : super(
+          pageBuilder: (context, animation, secondaryAnimation) =>
+              builder(context),
+          transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+              child,
+        );
+}

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,0 +1,113 @@
+import 'package:demo_app/models/person.dart';
+import 'package:demo_app/repository/person_repository.dart';
+import 'package:demo_app/widgets/floating_filter.dart';
+import 'package:demo_app/widgets/person_card.dart';
+import 'package:flutter/material.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key, required this.personRepository});
+
+  final PersonRepository personRepository;
+
+  @override
+  State createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomePage> {
+  late Future<List<Person>> _peopleFuture;
+
+  final ScrollController _scrollController = ScrollController();
+  bool _isVisible = true;
+  double _lastOffset = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_scrollListener);
+    _fetchPeople();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_scrollListener);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _scrollListener() {
+    double currentOffset = _scrollController.offset;
+    if (currentOffset > _lastOffset && _isVisible) {
+      setState(() {
+        _isVisible = false;
+      });
+    } else if (currentOffset < _lastOffset && !_isVisible) {
+      setState(() {
+        _isVisible = true;
+      });
+    }
+    _lastOffset = currentOffset;
+  }
+
+  void _fetchPeople() {
+    _peopleFuture = widget.personRepository.getPeople();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: FutureBuilder<List<Person>>(
+        future: _peopleFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return Container(
+                color: const Color(0xFFFFF45A).withOpacity(0.5),
+                padding: const EdgeInsets.all(12),
+                child: const Center(child: CircularProgressIndicator()));
+          } else if (snapshot.hasError) {
+            return const Scaffold(
+              body: Center(
+                child: Text('Error'),
+              ),
+            );
+          } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Scaffold(
+              body: Center(
+                child: Text('No people'),
+              ),
+            );
+          } else {
+            final people = snapshot.data!;
+            return SizedBox(
+              child: SafeArea(
+                child: Scaffold(
+                  body: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Stack(
+                      children: [
+                        FloatingFilter(isVisible: _isVisible),
+                        AnimatedPadding(
+                          duration: const Duration(milliseconds: 250),
+                          padding: EdgeInsets.only(
+                            top: !_isVisible ? 0 : FloatingFilter.heightOffset,
+                          ),
+                          child: ListView.builder(
+                            shrinkWrap: true,
+                            physics: const ClampingScrollPhysics(),
+                            controller: _scrollController,
+                            itemCount: people.length,
+                            itemBuilder: (_, index) =>
+                                PersonCard(person: people[index]),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            );
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/splash_page.dart
+++ b/lib/pages/splash_page.dart
@@ -1,5 +1,9 @@
 import 'dart:io' show Platform;
 import 'package:demo_app/assets/animations/animations_enum.dart';
+import 'package:demo_app/navigation/utils.dart';
+import 'package:demo_app/pages/home_page.dart';
+import 'package:demo_app/repository/person_repository.dart';
+import 'package:demo_app/services/app_api.dart';
 import 'package:demo_app/widgets/lottie_animation_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -18,6 +22,7 @@ class _SplashPageState extends State<SplashPage> with TickerProviderStateMixin {
   late Animation<BorderRadius?> _borderRadiusAnimation;
   late Animation<Color?> _colorAnimation;
 
+  final appApi = AppApi();
   final isMobile = Platform.isIOS || Platform.isAndroid;
 
   @override
@@ -31,12 +36,9 @@ class _SplashPageState extends State<SplashPage> with TickerProviderStateMixin {
 
     _lottieController.forward().whenComplete(
           () => Navigator.of(context).pushReplacement(
-            MaterialPageRoute(
-              builder: (_) => const Scaffold(
-                body: Center(
-                  child: Text('Bare bones'),
-                ),
-              ),
+            NoAnimationRoute(
+              builder: (_) =>
+                  HomePage(personRepository: PersonRepository(appApi: appApi)),
             ),
           ),
         );

--- a/lib/utils/date_formatter.dart
+++ b/lib/utils/date_formatter.dart
@@ -1,0 +1,7 @@
+import 'package:intl/intl.dart';
+
+class DateFormatter {
+  /// Parses date into MM DD,YYYY
+  static DateFormat get monthDateYear =>
+      DateFormat.yMMMd(Intl.getCurrentLocale());
+}

--- a/lib/widgets/floating_filter.dart
+++ b/lib/widgets/floating_filter.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class FloatingFilter extends StatefulWidget {
+  const FloatingFilter({super.key, required this.isVisible});
+
+  final bool isVisible;
+  static const heightOffset = 65.0;
+
+  @override
+  State<FloatingFilter> createState() => _FloatingFilterState();
+}
+
+class _FloatingFilterState extends State<FloatingFilter> {
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedPositioned(
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeInOut,
+      top: widget.isVisible ? 0 : -FloatingFilter.heightOffset,
+      left: 0,
+      right: 0,
+      child: Container(
+        padding: const EdgeInsets.only(left: 6),
+        margin: const EdgeInsets.symmetric(horizontal: 3),
+        decoration: BoxDecoration(
+          boxShadow: const [BoxShadow(color: Colors.grey, blurRadius: 2)],
+          borderRadius: BorderRadius.circular(6),
+          color: Colors.white,
+        ),
+        height: 60,
+        child: const Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // TODO add filter feature
+            Expanded(
+              child: Text('Filter Widget'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/person_card.dart
+++ b/lib/widgets/person_card.dart
@@ -1,0 +1,215 @@
+import 'package:demo_app/models/person.dart';
+import 'package:demo_app/utils/date_formatter.dart';
+import 'package:flutter/material.dart';
+
+class PersonCard extends StatelessWidget {
+  const PersonCard({super.key, required this.person});
+
+  final Person person;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget photoSectionBuilder() {
+      return Padding(
+        padding: const EdgeInsets.only(
+          right: 16,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 150,
+              height: 150,
+              margin: const EdgeInsets.only(bottom: 8),
+              clipBehavior: Clip.antiAlias,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Image.network(
+                '${person.photoUrl}',
+                fit: BoxFit.cover,
+              ),
+            ),
+            SizedBox(
+              width: 150,
+              child: Text(
+                '${person.titleProfession}',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: Colors.grey[700],
+                ),
+                softWrap: true,
+                textAlign: TextAlign.center,
+                overflow: TextOverflow.visible,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    Widget descriptionItemsBuilder() {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _CardEntry(
+            entryType: CardEntryEnum.name,
+            value: '${person.name} ${person.lastName}',
+            showDivider: false,
+            margin: const EdgeInsets.only(bottom: 20),
+          ),
+          _CardEntry(entryType: CardEntryEnum.birthday, value: person.birthday),
+          _CardEntry(entryType: CardEntryEnum.state, value: person.state),
+          _CardEntry(
+            entryType: CardEntryEnum.zipCode,
+            value: person.zip,
+            margin: const EdgeInsets.only(bottom: 18),
+          ),
+          _CardEntry(
+            entryType: CardEntryEnum.quote,
+            value: person.quote,
+            showDivider: false,
+          ),
+        ],
+      );
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+      margin: const EdgeInsets.symmetric(vertical: 6, horizontal: 3),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(6),
+        boxShadow: const [BoxShadow(color: Colors.grey, blurRadius: 2)],
+        color: Colors.white,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          photoSectionBuilder(),
+          descriptionItemsBuilder(),
+        ],
+      ),
+    );
+  }
+}
+
+enum CardEntryEnum {
+  name(),
+  birthday(label: 'Birthday', icon: Icons.cake),
+  state(label: 'State', icon: Icons.location_on),
+  zipCode(label: 'Zip Code', icon: Icons.numbers),
+  quote();
+
+  const CardEntryEnum({this.label = '', this.icon});
+
+  final String? label;
+  final IconData? icon;
+}
+
+class _CardEntry extends StatelessWidget {
+  const _CardEntry({
+    this.value = 'N/A',
+    required this.entryType,
+    this.showDivider = true,
+    this.margin = const EdgeInsets.only(bottom: 12),
+  });
+
+  final CardEntryEnum entryType;
+  final String? value;
+  final bool showDivider;
+  final EdgeInsets margin;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDate = entryType == CardEntryEnum.birthday;
+    final isQuote = entryType == CardEntryEnum.quote;
+    final isDefault = !(entryType == CardEntryEnum.name || isQuote);
+
+    final text = '${entryType.label}'
+    '${isDefault ? ": " : ''}'
+    '${isQuote ? '"$value"' : isDate
+        ? DateFormatter.monthDateYear.format(DateTime.parse(value!))
+        : value}';
+
+    final fontSyle = switch (entryType) {
+      CardEntryEnum.name => const TextStyle(
+          fontSize: 20.0,
+          fontWeight: FontWeight.bold,
+          height: 1,
+        ),
+      CardEntryEnum.quote => TextStyle(
+          fontStyle: FontStyle.italic,
+          color: Colors.blueGrey[700],
+          height: 1,
+        ),
+      CardEntryEnum.birthday => TextStyle(
+          fontSize: 14.0,
+          color: Colors.grey[600],
+          height: 1,
+        ),
+      CardEntryEnum.state => TextStyle(
+          fontSize: 14.0,
+          color: Colors.grey[600],
+          height: 1,
+        ),
+      CardEntryEnum.zipCode => TextStyle(
+          fontSize: 14.0,
+          color: Colors.grey[600],
+          height: 1,
+        ),
+    };
+
+    return Container(
+      margin: margin,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (isDefault)
+                Padding(
+                  padding: const EdgeInsets.only(right: 6),
+                  child: Icon(
+                    entryType.icon,
+                    size: 16.0,
+                    color: Colors.grey[600],
+                  ),
+                ),
+              SizedBox(
+                width: 180,
+                child: Text(
+                  text,
+                  style: fontSyle,
+                  softWrap: true,
+                  overflow: TextOverflow.visible,
+                  textAlign: isQuote ? TextAlign.center : null,
+                ),
+              ),
+            ],
+          ),
+          if (showDivider) const _CardEntryDivider()
+        ],
+      ),
+    );
+  }
+}
+
+class _CardEntryDivider extends StatelessWidget {
+  const _CardEntryDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(2),
+        color: Colors.grey[600],
+      ),
+      clipBehavior: Clip.antiAlias,
+      margin: const EdgeInsets.only(top: 6),
+      height: 1.5,
+      width: 180,
+    );
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <window_size/window_size_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) window_size_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowSizePlugin");
+  window_size_plugin_register_with_registrar(window_size_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  window_size
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,13 @@ dependencies:
   dio_smart_retry: ^6.0.0
   flutter:
     sdk: flutter
+  intl: ^0.19.0
   json_annotation: ^4.9.0
   lottie: ^3.1.2
+  window_size:
+    git:
+      url: https://github.com/google/flutter-desktop-embedding.git
+      path: plugins/window_size
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,8 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
+#include <window_size/window_size_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
+  WindowSizePluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowSizePlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   connectivity_plus
+  window_size
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
**Overview**

This merge brings a couple of things into the app, those which are listed below:

1. Adding Homescreen that consumes people API
2. Adding app window  size constraints through windows_size package
3. Adding app orientation constraint to Portrait up
4. Adding filter "container" which animates on scroll as intended (the widget is yet to come)
5. Adding some Dart lint to write cohesive code
6. Updates to the code serialization which were preventing proper json parsing
7. A utility to parse dates into the expected format

UI will probably be updated into a better version and colors should be handled by themes instead but that work will be addressed in further iterations.

**MacOS demo** 

https://github.com/user-attachments/assets/dfc1d267-6b83-4685-b3f5-8815b0b9798b


**iOS demo** 

https://github.com/user-attachments/assets/41a24feb-e131-4c0b-b6f9-3fb383e8ef93

**Android demo** 


https://github.com/user-attachments/assets/7ade0238-2a8e-4601-908a-3f2a7112a59c


