### PR TITLE
feat(filter): adding core filter functionality

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:demo_app/pages/splash_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:window_size/window_size.dart';
 
 Future<void> main() async {
@@ -16,7 +17,7 @@ Future<void> main() async {
     setWindowMinSize(const Size(500, 600));
   }
 
-  runApp(const MainApp());
+  runApp(const ProviderScope(child: MainApp()));
 }
 
 class MainApp extends StatelessWidget {

--- a/lib/providers/filter_provider.dart
+++ b/lib/providers/filter_provider.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class FilterState {
+  final String searchText;
+  final Set<String> selectedStates;
+
+  FilterState({
+    this.searchText = '',
+    this.selectedStates = const {},
+  });
+
+  FilterState copyWith({
+    String? searchText,
+    Set<String>? selectedStates,
+  }) {
+    return FilterState(
+      searchText: searchText ?? this.searchText,
+      selectedStates: selectedStates ?? this.selectedStates,
+    );
+  }
+}
+
+class FilterNotifier extends StateNotifier<FilterState> {
+  FilterNotifier() : super(FilterState());
+
+  void setSearchText(String text) {
+    state = state.copyWith(searchText: text);
+  }
+
+  void toggleStateSelection(String stateName) {
+    final newSelectedStates = Set<String>.from(state.selectedStates);
+    if (newSelectedStates.contains(stateName)) {
+      newSelectedStates.remove(stateName);
+    } else {
+      newSelectedStates.add(stateName);
+    }
+    state = state.copyWith(selectedStates: newSelectedStates);
+  }
+
+  void clearSelections() {
+    state = state.copyWith(selectedStates: {});
+  }
+
+  void clearAllFilters() {
+    state = FilterState();
+  }
+}
+
+final filterProvider =
+    StateNotifierProvider<FilterNotifier, FilterState>((ref) {
+  return FilterNotifier();
+});

--- a/lib/providers/filtered_people_provider.dart
+++ b/lib/providers/filtered_people_provider.dart
@@ -1,0 +1,26 @@
+import 'package:demo_app/providers/filter_provider.dart';
+import 'package:demo_app/providers/person_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:demo_app/models/person.dart';
+
+final filteredPeopleProvider = Provider<List<Person>>((ref) {
+  final peopleAsync = ref.watch(peopleProvider);
+  final filter = ref.watch(filterProvider);
+
+  return peopleAsync.when(
+    data: (people) {
+      return people.where((person) {
+        final matchesSearch = person.name
+            ?.toLowerCase()
+            .contains(filter.searchText.toLowerCase());
+        final matchesState = filter.selectedStates.isEmpty ||
+            filter.selectedStates.contains(person.state);
+
+        if (matchesSearch == null) return false;
+        return matchesSearch && matchesState;
+      }).toList();
+    },
+    loading: () => [],
+    error: (_, __) => [],
+  );
+});

--- a/lib/providers/person_repository.dart
+++ b/lib/providers/person_repository.dart
@@ -1,0 +1,8 @@
+import 'package:demo_app/providers/repository_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:demo_app/models/person.dart';
+
+final peopleProvider = FutureProvider<List<Person>>((ref) async {
+  final repository = ref.watch(personRepositoryProvider);
+  return repository.getPeople();
+});

--- a/lib/providers/repository_provider.dart
+++ b/lib/providers/repository_provider.dart
@@ -1,0 +1,12 @@
+import 'package:demo_app/repository/person_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:demo_app/services/app_api.dart';
+
+final appApiProvider = Provider<AppApi>((ref) {
+  return AppApi();
+});
+
+final personRepositoryProvider = Provider<PersonRepository>((ref) {
+  final appApi = ref.watch(appApiProvider);
+  return PersonRepository(appApi: appApi);
+});

--- a/lib/widgets/floating_filter.dart
+++ b/lib/widgets/floating_filter.dart
@@ -1,18 +1,30 @@
+import 'package:demo_app/providers/person_repository.dart';
+import 'package:demo_app/widgets/state_filter.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class FloatingFilter extends StatefulWidget {
+class FloatingFilter extends ConsumerStatefulWidget {
   const FloatingFilter({super.key, required this.isVisible});
 
   final bool isVisible;
-  static const heightOffset = 65.0;
+  static const heightOffset = 125.0;
 
   @override
-  State<FloatingFilter> createState() => _FloatingFilterState();
+  ConsumerState createState() => _FloatingFilterState();
 }
 
-class _FloatingFilterState extends State<FloatingFilter> {
+class _FloatingFilterState extends ConsumerState<FloatingFilter> {
   @override
   Widget build(BuildContext context) {
+    final peopleAsync = ref.watch(peopleProvider);
+
+    final List<String> uniqueStates = peopleAsync.when(
+      data: (people) =>
+          people.map((p) => p.state).whereType<String>().toSet().toList(),
+      loading: () => [],
+      error: (_, __) => [],
+    )..sort();
+
     return AnimatedPositioned(
       duration: const Duration(milliseconds: 250),
       curve: Curves.easeInOut,
@@ -22,20 +34,19 @@ class _FloatingFilterState extends State<FloatingFilter> {
       child: Container(
         padding: const EdgeInsets.only(left: 6),
         margin: const EdgeInsets.symmetric(horizontal: 3),
+        height: 120,
         decoration: BoxDecoration(
-          boxShadow: const [BoxShadow(color: Colors.grey, blurRadius: 2)],
+          boxShadow: const [
+            BoxShadow(
+              color: Colors.grey,
+              blurRadius: 2,
+            )
+          ],
           borderRadius: BorderRadius.circular(6),
           color: Colors.white,
         ),
-        height: 60,
-        child: const Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            // TODO add filter feature
-            Expanded(
-              child: Text('Filter Widget'),
-            ),
-          ],
+        child: StateFilter(
+          states: uniqueStates,
         ),
       ),
     );

--- a/lib/widgets/person_card.dart
+++ b/lib/widgets/person_card.dart
@@ -178,7 +178,7 @@ class _CardEntry extends StatelessWidget {
                   ),
                 ),
               SizedBox(
-                width: 180,
+                width: 155,
                 child: Text(
                   text,
                   style: fontSyle,

--- a/lib/widgets/state_filter.dart
+++ b/lib/widgets/state_filter.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:demo_app/providers/filter_provider.dart';
+
+class StateFilter extends ConsumerWidget {
+  final List<String> states;
+
+  const StateFilter({super.key, required this.states});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filter = ref.watch(filterProvider);
+    final filterNotifier = ref.read(filterProvider.notifier);
+
+    return states.isEmpty
+        ? const Center(
+            child: Padding(
+              padding: EdgeInsets.all(6),
+              child: CircularProgressIndicator(),
+            ),
+          )
+        : Column(
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.all(6),
+                      child: TextField(
+                        decoration: const InputDecoration(
+                          labelText: 'Search by name',
+                          prefixIcon: Icon(Icons.search),
+                          border: OutlineInputBorder(),
+                        ),
+                        style: const TextStyle(fontSize: 16, height: 0.8),
+                        onChanged: (value) {
+                          filterNotifier.setSearchText(value);
+                        },
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(right: 10),
+                    child: IconButton(
+                      icon: const Icon(
+                        Icons.delete,
+                        color: Colors.grey,
+                      ),
+                      onPressed: filterNotifier.clearAllFilters,
+                    ),
+                  )
+                ],
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: SizedBox(
+                      height: 50,
+                      child: ListView.builder(
+                        scrollDirection: Axis.horizontal,
+                        itemCount: states.length,
+                        itemBuilder: (_, index) {
+                          final isSelected =
+                              filter.selectedStates.contains(states[index]);
+                          return Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 4),
+                            child: FilterChip(
+                              label: Text(states[index]),
+                              selected: isSelected,
+                              onSelected: (_) {
+                                filterNotifier
+                                    .toggleStateSelection(states[index]);
+                              },
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   dio_smart_retry: ^6.0.0
   flutter:
     sdk: flutter
+  flutter_riverpod: ^2.5.1
   intl: ^0.19.0
   json_annotation: ^4.9.0
   lottie: ^3.1.2


### PR DESCRIPTION
**Overview**

This commit adds plenty of functionality, leveraging the state management library Riverpod. Following are the apps new feature and some architectural updates:

1. Api requests are now handle by Riverpod's Future provider, allowing data to be able to be easy to access from every consumer widget
2. Filter functionality was added, at the moment not within a dropdown menu since it made more sense to have it as a selectable list from the UI/UX perspective, however the dropdown will be implemented in further iterations
3. In addition to that, a "clear filters" buttons was added to remove currently selected states
4. A search bar was added to allow users to search people by first name, this will probably change in the future to also allow people to states by typing
5. People are correctly filtered when the chips/search are used

**MacOS demo**

https://github.com/user-attachments/assets/e1e1d684-a38c-4c53-b0ae-2be768168f7e


**iOS demo**

https://github.com/user-attachments/assets/97a6ae4e-1c0f-4938-9dba-58a6fe8d63fb


**Android demo**

https://github.com/user-attachments/assets/a7f443ae-979c-4a67-a268-a7f7433d7a90

